### PR TITLE
Fix compatible error with haskell-src-exts-1.17.1 and GHC 8.0.1.

### DIFF
--- a/hs2dot.cabal
+++ b/hs2dot.cabal
@@ -66,7 +66,7 @@ executable hs2dot
   Main-is: Main.hs          
   
   -- Packages needed in order to build this package.
-  build-depends:       base >= 4 && < 5, directory >= 1.0 && < 1.1, split >= 0.1.2, haskell-src-exts >= 1.9 && < 2.0, haskell98, haskell-src >= 1.0 && < 1.1
+  build-depends:       base >= 4 && < 5, directory >= 1.0 && < 1.3, split >= 0.1.2, haskell-src-exts >= 1.9 && < 2.0, haskell-src >= 1.0 && < 1.1
   
   -- Modules not exported by this package.
   Other-modules:       Hs2Dot.Helper, Hs2Dot.Src, Hs2Dot.SrcHelper, Hs2Dot.DotHelper, Hs2Dot.Dot

--- a/src/Hs2Dot/Src.hs
+++ b/src/Hs2Dot/Src.hs
@@ -75,7 +75,7 @@ decl2dot conf names moduleName (E.ClassDecl _ _ name _ _ _) = name'
   where
     name' = showClassDecl (pretty name) moduleName []
 
-decl2dot conf names moduleName (E.InstDecl _ _ qname types _) = show'
+decl2dot conf names moduleName (E.InstDecl _ _ _ _ qname types _) = show'
   where
     show' = if 1 == length types && isInNames names name' && isInNames names dataTypeName
             then showRef'

--- a/src/Hs2Dot/SrcHelper.hs
+++ b/src/Hs2Dot/SrcHelper.hs
@@ -51,7 +51,7 @@ name2fullname moduleName name = Just $ FullName name' (dot2Dash moduleName ++ "_
 
 -- | Can remove and transform FullName depending on ImportDecl.
 transformNameOnImport :: String -> ImportDecl -> FullName -> Maybe FullName       
-transformNameOnImport nameOfThisModule (ImportDecl iLoc (ModuleName iName) iQual _ _ iAlias iSpecs) fullname = result
+transformNameOnImport nameOfThisModule (ImportDecl iLoc (ModuleName iName) iQual _ _ _ iAlias iSpecs) fullname = result
   where
     result = if fullNameModule fullname == nameOfThisModule
              then Just fullname
@@ -82,10 +82,10 @@ transformNameOnImport nameOfThisModule (ImportDecl iLoc (ModuleName iName) iQual
 -- bangType2String = prettyPrint
 
 -- | Returns the (name,type) pretty-printed 
-nameBangType2String :: ([Name],E.BangType) -> (String, String)
+nameBangType2String :: ([Name],E.Type) -> (String, String)
 nameBangType2String (names,bangType) = (maybe "" prettyPrint $ listToMaybe names, pretty bangType)
 
-bangType2StringIfInNames :: [FullName] -> E.BangType ->  Maybe String
+bangType2StringIfInNames :: [FullName] -> E.Type ->  Maybe String
 bangType2StringIfInNames names bangType = result
   where
     nameOfBangType = pretty bangType
@@ -100,7 +100,7 @@ bangType2StringIfInNames names bangType = result
 class Pretty a where
   pretty :: a -> String
 
-instance Pretty E.BangType where
+instance Pretty E.Type where
   pretty = prettyPrint
 
 instance Pretty E.Name where
@@ -113,6 +113,6 @@ instance Pretty E.ModuleName where
 
 instance Pretty ImportSpec where
   pretty (IVar n) = prettyPrint n
-  pretty (IAbs n) = prettyPrint n
+  pretty (IAbs _ n) = prettyPrint n
   pretty (IThingAll n) = prettyPrint n
   pretty (IThingWith n _) = prettyPrint n


### PR DESCRIPTION
I updated version number of some dependencies, remove unused haskell98 package, and fix compatible error with GHC 8.0.1.
